### PR TITLE
Fix memory leak

### DIFF
--- a/src/GeneratesIdsTrait.php
+++ b/src/GeneratesIdsTrait.php
@@ -100,6 +100,11 @@ trait GeneratesIdsTrait
         // Put things back where they belong when you're finished with them
         ini_restore("precision");
 
+        // For long running processes, limit maximum array size
+        if (count($taken) >= 1000) {
+            array_shift($taken);
+        }
+
         return $taken[$id] = $id;
     }
 


### PR DESCRIPTION
This PR addresses a memory leak issue, detailed in issue https://github.com/adamthehutt/laravel-unique-bigint-ids/issues/4. This becomes emergent when dealing with long-running processes

The proposed solution is to limit the size of the static "taken ids" array by shifting off off the oldest taken id. A maximum array count number sufficiently high like 1000 may be a decent balance between performance, collision avoidance (due to a reasonable time passage), and moderate memory usage.